### PR TITLE
Remove the top-level expect

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -260,7 +260,14 @@ module.exports = {
   installInto: function(expect) {
     expect = expect.child();
     expect.use(require('magicpen-prism'));
-    var topLevelExpect = expect;
+
+    function bubbleError(body) {
+      return expect.withError(body, function(err) {
+        err.errorMode = 'bubble';
+        throw err;
+      });
+    }
+
     expect.exportType({
       name: 'DOMNode',
       base: 'object',
@@ -700,11 +707,9 @@ module.exports = {
             if (typeof value === 'string') {
               value = getClassNamesFromAttributeValue(value);
             }
-            return topLevelExpect(
-              actualClasses.sort(),
-              'to equal',
-              value.sort()
-            );
+            return bubbleError(function() {
+              return expect(actualClasses.sort(), 'to equal', value.sort());
+            });
           }
         });
       }
@@ -966,11 +971,13 @@ module.exports = {
         var promiseByKey = {
           name: expect.promise(function() {
             if (value && typeof value.name !== 'undefined') {
-              return topLevelExpect(
-                isHtml ? subject.nodeName.toLowerCase() : subject.nodeName,
-                'to satisfy',
-                value.name
-              );
+              return bubbleError(function() {
+                return expect(
+                  isHtml ? subject.nodeName.toLowerCase() : subject.nodeName,
+                  'to satisfy',
+                  value.name
+                );
+              });
             }
           }),
           children: expect.promise(function() {
@@ -980,20 +987,24 @@ module.exports = {
                   'The children and textContent properties are not supported together'
                 );
               }
-              return topLevelExpect(
-                makeAttachedDOMNodeList(
-                  subject.childNodes,
-                  subject.ownerDocument.contentType
-                ),
-                'to satisfy',
-                value.children
-              );
+              return bubbleError(function() {
+                return expect(
+                  makeAttachedDOMNodeList(
+                    subject.childNodes,
+                    subject.ownerDocument.contentType
+                  ),
+                  'to satisfy',
+                  value.children
+                );
+              });
             } else if (typeof value.textContent !== 'undefined') {
-              return topLevelExpect(
-                subject.textContent,
-                'to satisfy',
-                value.textContent
-              );
+              return bubbleError(function() {
+                return expect(
+                  subject.textContent,
+                  'to satisfy',
+                  value.textContent
+                );
+              });
             }
           }),
           attributes: {}
@@ -1032,15 +1043,13 @@ module.exports = {
               expectedValueByAttributeName[attributeName];
             promiseByKey.attributes[attributeName] = expect.promise(function() {
               if (expectedAttributeValue === true) {
-                topLevelExpect(
-                  subject.hasAttribute(attributeName),
-                  'to be true'
-                );
+                return bubbleError(function() {
+                  expect(subject.hasAttribute(attributeName), 'to be true');
+                });
               } else if (typeof expectedAttributeValue === 'undefined') {
-                topLevelExpect(
-                  subject.hasAttribute(attributeName),
-                  'to be false'
-                );
+                return bubbleError(function() {
+                  expect(subject.hasAttribute(attributeName), 'to be false');
+                });
               } else if (
                 attributeName === 'class' &&
                 (typeof expectedAttributeValue === 'string' ||
@@ -1056,19 +1065,25 @@ module.exports = {
                   );
                 }
                 if (onlyAttributes) {
-                  return topLevelExpect(
-                    actualClasses.sort(),
-                    'to equal',
-                    expectedClasses.sort()
-                  );
+                  return bubbleError(function() {
+                    return expect(
+                      actualClasses.sort(),
+                      'to equal',
+                      expectedClasses.sort()
+                    );
+                  });
                 } else {
                   if (expectedClasses.length === 0) {
-                    return topLevelExpect(expectedClasses, 'to be empty');
+                    return bubbleError(function() {
+                      return expect(expectedClasses, 'to be empty');
+                    });
                   }
-                  return topLevelExpect.apply(
-                    topLevelExpect,
-                    [actualClasses, 'to contain'].concat(expectedClasses)
-                  );
+                  return bubbleError(function() {
+                    return expect.apply(
+                      expect,
+                      [actualClasses, 'to contain'].concat(expectedClasses)
+                    );
+                  });
                 }
               } else if (attributeName === 'style') {
                 var expectedStyleObj;
@@ -1081,24 +1096,26 @@ module.exports = {
                 }
 
                 if (onlyAttributes) {
-                  return topLevelExpect(
-                    attrs.style,
-                    'to exhaustively satisfy',
-                    expectedStyleObj
-                  );
+                  return bubbleError(function() {
+                    return expect(
+                      attrs.style,
+                      'to exhaustively satisfy',
+                      expectedStyleObj
+                    );
+                  });
                 } else {
-                  return topLevelExpect(
-                    attrs.style,
-                    'to satisfy',
-                    expectedStyleObj
-                  );
+                  return bubbleError(function() {
+                    return expect(attrs.style, 'to satisfy', expectedStyleObj);
+                  });
                 }
               } else {
-                return topLevelExpect(
-                  attributeValue,
-                  'to satisfy',
-                  expectedAttributeValue
-                );
+                return bubbleError(function() {
+                  return expect(
+                    attributeValue,
+                    'to satisfy',
+                    expectedAttributeValue
+                  );
+                });
               }
             });
           });


### PR DESCRIPTION
When using the top-level expect instead of the wrapped expect, we will end up serializing errors that we shouldn't. This PR make sure that we will use the wrapped expect instead.