### PR TITLE
Convert children arrays to DOM specs prior to performing comparisons.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -742,6 +742,39 @@ module.exports = {
       }
     );
 
+    function convertChildrenToSatisfySpec(children, isHtml) {
+      return children.map(function(child) {
+        if (typeof child === 'object' || typeof child === 'function') {
+          return child;
+        }
+
+        var valueNode;
+        if (typeof child === 'string') {
+          if (!isHtml) {
+            // do not parse text as a node when using XML
+            return child;
+          }
+          var childNodes = (isHtml
+            ? parseHtml(child, true, expect.testDescription)
+            : parseXml(child, expect.testDescription)
+          ).childNodes;
+          if (childNodes.length > 1) {
+            expect.fail(function(output) {
+              output
+                .text('Only single node is supported as a child but saw ')
+                .appendInspected(childNodes);
+            });
+          }
+          valueNode = childNodes[0];
+        } else {
+          // DOMNode
+          valueNode = child;
+        }
+
+        return convertDOMNodeToSatisfySpec(valueNode, isHtml);
+      });
+    }
+
     function convertDOMNodeToSatisfySpec(node, isHtml) {
       if (node.nodeType === 8 && node.nodeValue.trim() === 'ignore') {
         // Ignore subtree
@@ -991,7 +1024,9 @@ module.exports = {
                     subject.ownerDocument.contentType
                   ),
                   'to satisfy',
-                  value.children
+                  Array.isArray(value.children)
+                    ? convertChildrenToSatisfySpec(value.children, isHtml)
+                    : value.children
                 );
               });
             } else if (typeof value.textContent !== 'undefined') {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2032,6 +2032,13 @@ describe('unexpected-dom', function() {
         expect(body.firstChild, 'to satisfy', { children: ['hey'] });
       });
 
+      it('should succeed with a complex child', function() {
+        body.innerHTML = '<div><div foo="bar">hey</div></div>';
+        expect(body.firstChild, 'to satisfy', {
+          children: ['<div foo="bar">hey</div>']
+        });
+      });
+
       it('should fail with a diff', function() {
         body.innerHTML = '<div foo="bar">hey</div>';
         expect(
@@ -2048,6 +2055,40 @@ describe('unexpected-dom', function() {
             '      // +there\n' +
             '</div>'
         );
+      });
+
+      it('should error if multiple nodes are supplied as a child', function() {
+        body.innerHTML = '<div><div foo="bar">hey</div></div>';
+        expect(
+          function() {
+            expect(body.firstChild, 'to satisfy', {
+              children: ['<div foo="bar">hey</div><div foo="bar">there</div>']
+            });
+          },
+          'to throw',
+          'expected <div><div foo="bar">hey</div></div>\n' +
+            'to satisfy { children: [ \'<div foo="bar">hey</div><div foo="bar">there</div>\' ] }\n' +
+            '\n' +
+            '<div>\n' +
+            '  <div foo="bar">hey</div> // Only single node is supported as a child but saw NodeList[ <div foo="bar">hey</div>, <div foo="bar">there</div> ]\n' +
+            '\n' +
+            '</div>'
+        );
+      });
+
+      describe('when using ignore', function() {
+        it('should succeed', function() {
+          body.innerHTML =
+            '<div><span>ignore</span><span>important</span></div>';
+          expect(body.firstChild, 'to satisfy', {
+            children: [
+              '<!-- ignore -->',
+              {
+                children: 'important'
+              }
+            ]
+          });
+        });
       });
     });
 
@@ -2621,6 +2662,31 @@ describe('unexpected-dom', function() {
       ).then(function(document) {
         expect(document, 'queried for first', 'fooBar', 'to have attributes', {
           yes: 'sir'
+        });
+      });
+    });
+
+    describe('to satisfy', function() {
+      describe('when comparing an array of children', function() {
+        it('should succeed with text child', function() {
+          expect(
+            [
+              '<?xml version="1.0"?>',
+              '<content>',
+              '  <hello type="greeting">World</hello>',
+              '</content>'
+            ].join('\n'),
+            'when parsed as XML',
+            'queried for first',
+            'hello',
+            'to satisfy',
+            {
+              attributes: {
+                type: 'greeting'
+              },
+              children: ['World']
+            }
+          );
         });
       });
     });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2039,6 +2039,15 @@ describe('unexpected-dom', function() {
         });
       });
 
+      it('should succeed with a node child', function() {
+        var node = document.createElement('div');
+        node.innerHTML = '<div foo="bar">hey</div>';
+        body.innerHTML = '<div><div foo="bar">hey</div></div>';
+        expect(body.firstChild, 'to satisfy', {
+          children: [node.firstChild]
+        });
+      });
+
       it('should fail with a diff', function() {
         body.innerHTML = '<div foo="bar">hey</div>';
         expect(
@@ -2668,7 +2677,7 @@ describe('unexpected-dom', function() {
 
     describe('to satisfy', function() {
       describe('when comparing an array of children', function() {
-        it('should succeed with text child', function() {
+        it('should succeed with a text child', function() {
           expect(
             [
               '<?xml version="1.0"?>',
@@ -2685,6 +2694,19 @@ describe('unexpected-dom', function() {
                 type: 'greeting'
               },
               children: ['World']
+            }
+          );
+        });
+
+        it('should succeed with a complex child', function() {
+          expect(
+            '<?xml version="1.0"?><content><hello type="greeting">World</hello></content>',
+            'when parsed as XML',
+            'queried for first',
+            'content',
+            'to satisfy',
+            {
+              children: ['<hello type="greeting">World</hello>']
             }
           );
         });


### PR DESCRIPTION
As of this commit the full DOMNode to spec conversion is run for all
children specified as strings which allows ignore syntax to work.

Fixes https://github.com/unexpectedjs/unexpected-dom/issues/217.