### PR TITLE
Fix comment nodes being specified as children in a satisfy spec.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -742,6 +742,16 @@ module.exports = {
       }
     );
 
+    function convertChildrenToSatisfySpec(children, isHtml) {
+      return children.map(function(child) {
+        if (expect.findTypeOf(child).is('DOMNode')) {
+          return convertDOMNodeToSatisfySpec(child, isHtml);
+        } else {
+          return child;
+        }
+      });
+    }
+
     function convertDOMNodeToSatisfySpec(node, isHtml) {
       if (node.nodeType === 8 && node.nodeValue.trim() === 'ignore') {
         // Ignore subtree
@@ -991,7 +1001,9 @@ module.exports = {
                     subject.ownerDocument.contentType
                   ),
                   'to satisfy',
-                  value.children
+                  Array.isArray(value.children)
+                    ? convertChildrenToSatisfySpec(value.children, isHtml)
+                    : value.children
                 );
               });
             } else if (typeof value.textContent !== 'undefined') {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2032,6 +2032,15 @@ describe('unexpected-dom', function() {
         expect(body.firstChild, 'to satisfy', { children: ['hey'] });
       });
 
+      it('should succeed with a node child', function() {
+        var node = document.createElement('div');
+        node.innerHTML = '<div foo="bar">hey</div>';
+        body.innerHTML = '<div><div foo="bar">hey</div></div>';
+        expect(body.firstChild, 'to satisfy', {
+          children: [node.firstChild]
+        });
+      });
+
       it('should fail with a diff', function() {
         body.innerHTML = '<div foo="bar">hey</div>';
         expect(
@@ -2048,6 +2057,24 @@ describe('unexpected-dom', function() {
             '      // +there\n' +
             '</div>'
         );
+      });
+
+      describe('when using ignore', function() {
+        it('should succeed', function() {
+          var node = document.createElement('div');
+          node.innerHTML = '<!-- ignore -->';
+          var commentNode = node.firstChild;
+          body.innerHTML =
+            '<div><span>ignore</span><span>important</span></div>';
+          expect(body.firstChild, 'to satisfy', {
+            children: [
+              commentNode,
+              {
+                children: 'important'
+              }
+            ]
+          });
+        });
       });
     });
 
@@ -2621,6 +2648,31 @@ describe('unexpected-dom', function() {
       ).then(function(document) {
         expect(document, 'queried for first', 'fooBar', 'to have attributes', {
           yes: 'sir'
+        });
+      });
+    });
+
+    describe('to satisfy', function() {
+      describe('when comparing an array of children', function() {
+        it('should succeed with a text child', function() {
+          expect(
+            [
+              '<?xml version="1.0"?>',
+              '<content>',
+              '  <hello type="greeting">World</hello>',
+              '</content>'
+            ].join('\n'),
+            'when parsed as XML',
+            'queried for first',
+            'hello',
+            'to satisfy',
+            {
+              attributes: {
+                type: 'greeting'
+              },
+              children: ['World']
+            }
+          );
         });
       });
     });


### PR DESCRIPTION
This is a backwards compatible version of the previous PR that ensures that any DOMNode present in the `children` property of an object spec is converted before comparison.

Fixes https://github.com/unexpectedjs/unexpected-dom/issues/217.