### PR TITLE
First class support for test id's

### DIFF
--- a/documentation/assertions/DOMElement/queried-for-test-id.md
+++ b/documentation/assertions/DOMElement/queried-for-test-id.md
@@ -1,0 +1,78 @@
+Queries the subject element for the first descendant element with the given `data-test-id`
+attribute and forwards it to another assertion.
+
+If the data-test-id is not found it fails.
+
+```js
+var element = createElement(`
+  <section>
+    <h1>Numbers</h1>
+    <hr>
+    <ol data-test-id="numbers">
+      <li >One</li>
+      <li>Two</li>
+      <li>Three</li>
+    </ol>
+  </section>
+`);
+
+expect(element, 'queried for test id', 'numbers', 'to satisfy', {
+  children: expect.it('to have length', 3)
+});
+```
+
+If no matching element can be found you get the following error:
+
+```js
+expect(element, 'queried for test id', 'emojies', 'to satisfy', {
+  children: expect.it('to have length', 666)
+});
+```
+
+```output
+expected
+<section>
+  <h1>Numbers</h1>
+  <hr>
+  <ol data-test-id="numbers">
+    <li>...</li>
+    <li>...</li>
+    <li>...</li>
+  </ol>
+</section>
+queried for test id 'emojies' to satisfy { children: expect.it('to have length', 666) }
+  expected DOMElement queried for first [data-test-id="emojies"]
+    The selector [data-test-id="emojies"] yielded no results
+```
+
+In case the next assertion fails you will get an error looking like this:
+
+```js
+expect(
+  element,
+  'queried for test id',
+  'numbers',
+  'to have no children'
+);
+```
+
+```output
+expected
+<section>
+  <h1>Numbers</h1>
+  <hr>
+  <ol data-test-id="numbers">
+    <li>...</li>
+    <li>...</li>
+    <li>...</li>
+  </ol>
+</section>
+queried for test id 'numbers' to have no children
+  expected
+  <ol data-test-id="numbers">
+    <li>One</li>
+    <li>Two</li>
+    <li>Three</li>
+  </ol>
+  to have no children
+```

--- a/documentation/assertions/DOMElement/queried-for.md
+++ b/documentation/assertions/DOMElement/queried-for.md
@@ -1,6 +1,6 @@
 Queries the subject element with the given CSS selector and forwards it to another assertion.
 
-If the selector doesn't match anything is fails.
+If the selector doesn't match anything it fails.
 
 ```js
 var element = createElement(`

--- a/documentation/assertions/DOMElement/to-contain-elements-matching.md
+++ b/documentation/assertions/DOMElement/to-contain-elements-matching.md
@@ -36,17 +36,17 @@ expected
 to contain elements matching '[data-test-id=emojies]'
 ```
 
-Using the `no` flag, you can assert that the selector can't matching any
+Using the `not` flag, you can assert that the selector can't matching any
 descendant elements:
 
 ```js
-expect(element, 'to contain no elements matching', '[data-test-id=emojies]');
+expect(element, 'not to contain elements matching', '[data-test-id=emojies]');
 ```
 
 You get the following error when it fails:
 
 ```js
-expect(element, 'to contain no elements matching', 'li');
+expect(element, 'not to contain elements matching', 'li');
 ```
 
 ```output
@@ -60,7 +60,7 @@ expected
     <li>...</li>
   </ol>
 </section>
-to contain no elements matching 'li'
+not to contain elements matching 'li'
 
 NodeList[
   <li>One</li>, // should be removed

--- a/documentation/assertions/DOMElement/to-contain-test-id.md
+++ b/documentation/assertions/DOMElement/to-contain-test-id.md
@@ -1,0 +1,75 @@
+Assert that an element contains a descendant element with element with the given `data-test-id`
+attribute.
+
+```js
+var element = createElement(`
+  <section>
+    <h1>Numbers</h1>
+    <hr>
+    <ol data-test-id="numbers">
+      <li>One</li>
+      <li>Two</li>
+      <li>Three</li>
+    </ol>
+  </section>
+`);
+
+expect(element, 'to contain test id', 'numbers');
+```
+
+You get the following error when it fails:
+
+```js
+expect(element, 'to contain test id', 'emojies');
+```
+
+```output
+expected
+<section>
+  <h1>Numbers</h1>
+  <hr>
+  <ol data-test-id="numbers">
+    <li>...</li>
+    <li>...</li>
+    <li>...</li>
+  </ol>
+</section>
+to contain test id 'emojies'
+  expected DOMElement to contain elements matching '[data-test-id="emojies"]'
+```
+
+Using the `not` flag, you can assert that the test id shouldn't be found on any
+descendant elements:
+
+```js
+expect(element, 'not to contain test id', 'emojies');
+```
+
+You get the following error when it fails:
+
+```js
+expect(element, 'not to contain test id', 'numbers');
+```
+
+```output
+expected
+<section>
+  <h1>Numbers</h1>
+  <hr>
+  <ol data-test-id="numbers">
+    <li>...</li>
+    <li>...</li>
+    <li>...</li>
+  </ol>
+</section>
+not to contain test id 'numbers'
+  expected DOMElement not to contain elements matching '[data-test-id="numbers"]'
+
+  NodeList[
+    <ol data-test-id="numbers">
+      <li>...</li>
+      <li>...</li>
+      <li>...</li>
+    </ol> // should be removed
+  ]
+```

--- a/documentation/assertions/DOMElement/to-have-test-id.md
+++ b/documentation/assertions/DOMElement/to-have-test-id.md
@@ -1,0 +1,47 @@
+Assert that an element have the given `data-test-id` attribute.
+
+```js
+var element = createElement(`
+  <button data-test-id="publish" class="primary" disabled>
+    Publish
+  </button>
+`);
+
+expect(element, 'to have test id', 'publish');
+```
+
+In case of a failing expectation you get the following output:
+
+```js
+expect(element, 'to have test id', 'approve');
+```
+
+```output
+expected
+<button data-test-id="publish" class="primary" disabled>
+  Publish
+</button>
+to have test id 'approve'
+  expected DOMElement to match '[data-test-id="approve"]'
+```
+
+You can also assert that an element does not have a test id:
+
+```js
+expect(element, 'not to have test id', 'approve');
+```
+
+In case of a failing expectation you get the following output:
+
+```js
+expect(element, 'not to have test id', 'publish');
+```
+
+```output
+expected
+<button data-test-id="publish" class="primary" disabled>
+  Publish
+</button>
+not to have test id 'publish'
+  expected DOMElement not to match '[data-test-id="publish"]'
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1483,6 +1483,23 @@ module.exports = {
     );
 
     expect.exportAssertion(
+      '<DOMDocument|DOMElement|DOMDocumentFragment> [not] to have test id <string>',
+      (expect, subject, testId) => {
+        expect.errorMode = 'nested';
+        expect.subjectOutput = output =>
+          expect.inspect(subject, Infinity, output);
+
+        const escapedTestId = JSON.stringify(testId);
+
+        return expect(
+          subject,
+          '[not] to match',
+          `[data-test-id=${escapedTestId}]`
+        );
+      }
+    );
+
+    expect.exportAssertion(
       '<string> [when] parsed as (html|HTML) [fragment] <assertion?>',
       (expect, subject) => {
         expect.errorMode = 'nested';

--- a/src/index.js
+++ b/src/index.js
@@ -1458,6 +1458,21 @@ module.exports = {
     );
 
     expect.exportAssertion(
+      '<DOMDocument|DOMElement|DOMDocumentFragment> [not] to contain test id <string>',
+      (expect, subject, testId) => {
+        expect.errorMode = 'nested';
+
+        const escapedTestId = JSON.stringify(testId);
+
+        return expect(
+          subject,
+          '[not] to contain elements matching',
+          `[data-test-id=${escapedTestId}]`
+        );
+      }
+    );
+
+    expect.exportAssertion(
       '<DOMDocument|DOMElement|DOMDocumentFragment> [not] to match <string>',
       (expect, subject, query) => {
         expect.subjectOutput = output =>

--- a/src/index.js
+++ b/src/index.js
@@ -1441,9 +1441,12 @@ module.exports = {
     );
 
     expect.exportAssertion(
-      '<DOMDocument|DOMElement|DOMDocumentFragment> to contain [no] elements matching <string>',
+      [
+        '<DOMDocument|DOMElement|DOMDocumentFragment> to contain [no] elements matching <string>',
+        '<DOMDocument|DOMElement|DOMDocumentFragment> [not] to contain elements matching <string>'
+      ],
       (expect, subject, query) => {
-        if (expect.flags.no) {
+        if (expect.flags.no || expect.flags.not) {
           return expect(subject.querySelectorAll(query), 'to satisfy', []);
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1426,6 +1426,21 @@ module.exports = {
     );
 
     expect.exportAssertion(
+      '<DOMDocument|DOMElement|DOMDocumentFragment> [when] queried for test id <string> <assertion?>',
+      (expect, subject, testId) => {
+        expect.errorMode = 'nested';
+
+        const escapedTestId = JSON.stringify(testId);
+
+        return expect(
+          subject,
+          'queried for first',
+          `[data-test-id=${escapedTestId}]`
+        ).then(queryResult => expect.shift(queryResult));
+      }
+    );
+
+    expect.exportAssertion(
       '<DOMDocument|DOMElement|DOMDocumentFragment> to contain [no] elements matching <string>',
       (expect, subject, query) => {
         if (expect.flags.no) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2627,13 +2627,13 @@ describe('unexpected-dom', () => {
     });
   });
 
-  describe('to contain no elements matching', () => {
+  describe('not to contain elements matching', () => {
     it('should pass when not matching anything', () => {
       const document = parseHtmlDocument(
         '<!DOCTYPE html><html><body></body></html>'
       );
 
-      expect(document, 'to contain no elements matching', '.foo');
+      expect(document, 'not to contain elements matching', '.foo');
     });
 
     it('should fail when matching a single node', () => {
@@ -2643,12 +2643,12 @@ describe('unexpected-dom', () => {
 
       expect(
         () => {
-          expect(document, 'to contain no elements matching', '.foo');
+          expect(document, 'not to contain elements matching', '.foo');
         },
         'to throw an error satisfying to equal snapshot',
         expect.unindent`
         expected <!DOCTYPE html><html><head></head><body>...</body></html>
-        to contain no elements matching '.foo'
+        not to contain elements matching '.foo'
 
         NodeList[
           <div class="foo"></div> // should be removed
@@ -2664,12 +2664,12 @@ describe('unexpected-dom', () => {
 
       expect(
         () => {
-          expect(document, 'to contain no elements matching', '.foo');
+          expect(document, 'not to contain elements matching', '.foo');
         },
         'to throw an error satisfying to equal snapshot',
         expect.unindent`
         expected <!DOCTYPE html><html><head></head><body>...</body></html>
-        to contain no elements matching '.foo'
+        not to contain elements matching '.foo'
 
         NodeList[
           <div class="foo"></div>, // should be removed

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2582,6 +2582,51 @@ describe('unexpected-dom', () => {
     });
   });
 
+  describe('queried for test id', () => {
+    it('should work with HTMLDocument', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body><div data-test-id="foo" id="foo"></div></body></html>'
+      );
+      expect(document, 'queried for test id', 'foo', 'to have attributes', {
+        id: 'foo'
+      });
+    });
+
+    it('should provide the results as the fulfillment value when no assertion is provided', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body><div data-test-id="foo" id="foo"></div></body></html>'
+      );
+      return expect(document, 'queried for test id', 'foo').then(div => {
+        expect(div, 'to have attributes', { id: 'foo' });
+      });
+    });
+
+    it('should error out if the selector matches no elements', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body><div data-test-id="foo"></div></body></html>'
+      );
+
+      expect(
+        () => {
+          expect(
+            document.body,
+            'queried for test id',
+            'blabla',
+            'to have attributes',
+            { id: 'foo' }
+          );
+        },
+        'to throw an error satisfying to equal snapshot',
+        expect.unindent`
+          expected <body><div data-test-id="foo"></div></body>
+          queried for test id 'blabla' to have attributes { id: 'foo' }
+            expected DOMElement queried for first [data-test-id="blabla"]
+              The selector [data-test-id="blabla"] yielded no results
+        `
+      );
+    });
+  });
+
   describe('to contain no elements matching', () => {
     it('should pass when not matching anything', () => {
       const document = parseHtmlDocument(

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2815,6 +2815,60 @@ describe('unexpected-dom', () => {
     });
   });
 
+  describe('to have test id', () => {
+    it('should pass if the element have the given test id', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body><div data-test-id="foo"></div></body></html>'
+      );
+
+      expect(document.body.firstChild, 'to have test id', 'foo');
+    });
+
+    it('should fail if the element does not have the given test id', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body><div data-test-id="foo"></div></body></html>'
+      );
+
+      expect(
+        () => {
+          expect(document.body.firstChild, 'to have test id', 'bar');
+        },
+        'to throw an error satisfying to equal snapshot',
+        expect.unindent`
+        expected <div data-test-id="foo"></div> to have test id 'bar'
+          expected <div data-test-id="foo"></div> to match '[data-test-id="bar"]'
+      `
+      );
+    });
+  });
+
+  describe('not to have test id', () => {
+    it('should pass if the element does not have the given test id', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body><div data-test-id="foo"></div></body></html>'
+      );
+
+      expect(document.body.firstChild, 'not to have test id', 'bar');
+    });
+
+    it('should fail if the element have the given test id', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body><div data-test-id="foo"></div></body></html>'
+      );
+
+      expect(
+        () => {
+          expect(document.body.firstChild, 'not to have test id', 'foo');
+        },
+        'to throw an error satisfying to equal snapshot',
+        expect.unindent`
+        expected <div data-test-id="foo"></div> not to have test id 'foo'
+          expected <div data-test-id="foo"></div> not to match '[data-test-id="foo"]'
+      `
+      );
+    });
+  });
+
   describe('when parsed as HTML', () => {
     const htmlSrc = '<!DOCTYPE html><html><body class="bar">foo</body></html>';
     it('should parse a string as a complete HTML document', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2711,6 +2711,64 @@ describe('unexpected-dom', () => {
     });
   });
 
+  describe('to contain test id', () => {
+    it('should pass when the test id is found', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body><div data-test-id="foo"></div></body></html>'
+      );
+
+      expect(document, 'to contain test id', 'foo');
+    });
+
+    it('should fail when the test id is not found', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body><div data-test-id="foo"></div><div data-test-id="bar"></div></body></html>'
+      );
+
+      expect(
+        () => {
+          expect(document, 'to contain test id', 'baz');
+        },
+        'to throw an error satisfying to equal snapshot',
+        expect.unindent`
+          expected <!DOCTYPE html><html><head></head><body>...</body></html> to contain test id 'baz'
+            expected HTMLDocument to contain elements matching '[data-test-id="baz"]'
+        `
+      );
+    });
+  });
+
+  describe('not to contain test id', () => {
+    it('should pass when the test id is not found ', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body></body></html>'
+      );
+
+      expect(document, 'not to contain test id', 'foo');
+    });
+
+    it('should fail when the test id is found', () => {
+      const document = parseHtmlDocument(
+        '<!DOCTYPE html><html><body><div data-test-id="foo"></div></body></html>'
+      );
+
+      expect(
+        () => {
+          expect(document, 'not to contain test id', 'foo');
+        },
+        'to throw an error satisfying to equal snapshot',
+        expect.unindent`
+          expected <!DOCTYPE html><html><head></head><body>...</body></html> not to contain test id 'foo'
+            expected HTMLDocument not to contain elements matching '[data-test-id="foo"]'
+
+            NodeList[
+              <div data-test-id="foo"></div> // should be removed
+            ]
+        `
+      );
+    });
+  });
+
   describe('to match', () => {
     it('should match an element correctly', () => {
       const document = parseHtmlDocument(


### PR DESCRIPTION
It is becoming a recognised pattern for DOM testing to use test id's on elements. 

Test id's is just a adding a `data-test-id` attribute to elements so you have a stable way of finding them from your tests.

We can already handle those, but it is kind of inconvenient and given how often it is used, I think we should add first class support for the concept. 

Fixes: #285