### PR TITLE
Export themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-node-resolve": "^5.0.0",
     "rollup-plugin-terser": "^5.1.2",
-    "unexpected": "git://github.com/unexpectedjs/unexpected.git#51c8fab",
+    "unexpected": "git://github.com/unexpectedjs/unexpected.git#ca41679",
     "unexpected-documentation-site-generator": "^6.0.0",
     "unexpected-markdown": "^4.0.0",
     "unexpected-snapshot": "^0.7.0"

--- a/package.json
+++ b/package.json
@@ -77,14 +77,14 @@
     "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-node-resolve": "^5.0.0",
     "rollup-plugin-terser": "^5.1.2",
-    "unexpected": "^11.6.1",
+    "unexpected": "git://github.com/unexpectedjs/unexpected.git#51c8fab",
     "unexpected-documentation-site-generator": "^6.0.0",
     "unexpected-markdown": "^4.0.0",
     "unexpected-snapshot": "^0.7.0"
   },
   "dependencies": {
     "extend": "^3.0.1",
-    "magicpen-prism": "^3.0.2"
+    "magicpen-prism": "git://github.com/unexpectedjs/magicpen-prism.git#4ef152e"
   },
   "peerDependencies": {
     "unexpected": "^10.27.0 || ^11.0.0-4"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-node-resolve": "^5.0.0",
     "rollup-plugin-terser": "^5.1.2",
-    "unexpected": "git://github.com/unexpectedjs/unexpected.git#ca41679",
+    "unexpected": "git://github.com/unexpectedjs/unexpected.git#fac75c7",
     "unexpected-documentation-site-generator": "^6.0.0",
     "unexpected-markdown": "^4.0.0",
     "unexpected-snapshot": "^0.7.0"

--- a/src/index.js
+++ b/src/index.js
@@ -268,6 +268,10 @@ module.exports = {
     expect = expect.child();
     expect.use(require('magicpen-prism'));
 
+    // export the items registered by magicpen-prism to callers
+    expect.exportTheme('html', expect.output.theme('html'));
+    expect.exportStyle('code', expect.output.styles.code);
+
     function bubbleError(body) {
       return expect.withError(body, err => {
         err.errorMode = 'bubble';

--- a/src/index.js
+++ b/src/index.js
@@ -266,11 +266,8 @@ module.exports = {
   name: 'unexpected-dom',
   installInto(expect) {
     expect = expect.child();
-    expect.use(require('magicpen-prism'));
 
-    // export the items registered by magicpen-prism to callers
-    expect.exportTheme('html', expect.output.theme('html'));
-    expect.exportStyle('code', expect.output.styles.code);
+    expect.exportPlugin(require('magicpen-prism'));
 
     function bubbleError(body) {
       return expect.withError(body, err => {

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -1342,5 +1342,37 @@ describe('"to satisfy" assertion', () => {
         })
       );
     });
+
+    it('should produce a good satisfy diff (html with nested assertion)', () => {
+      const expectWithExtra = expect
+        .clone()
+        .addAssertion(
+          '<DOMElement> with an empty span injected <assertion>',
+          (expect, subject) => {
+            subject.innerHTML = '<span></span>';
+            return expect.shift(subject);
+          }
+        );
+
+      expect(
+        () => {
+          expectWithExtra(
+            parseHtml('<div></div>'),
+            'with an empty span injected',
+            'to satisfy',
+            { textContent: 'foo' }
+          );
+        },
+        'to throw',
+        expect.it(error => {
+          const message = error.getErrorMessage('html').toString();
+          expect(
+            message,
+            'to equal', // not using snapshot to demonstrate an issue with the env var
+            '<div style="font-family: monospace; white-space: nowrap"><div><span style="color: red; font-weight: bold">expected</span>&nbsp;<span style="color: #999">&lt;</span><span style="color: #905">div</span><span style="color: #999">&gt;&lt;</span><span style="color: #905">span</span><span style="color: #999">&gt;&lt;/</span><span style="color: #905">span</span><span style="color: #999">&gt;&lt;/</span><span style="color: #905">div</span><span style="color: #999">&gt;</span>&nbsp;<span style="color: red; font-weight: bold">with&nbsp;an&nbsp;empty&nbsp;span&nbsp;injected</span>&nbsp;<span style="color: red; font-weight: bold">to&nbsp;satisfy</span>&nbsp;{&nbsp;<span style="color: #555">textContent</span>:&nbsp;<span style="color: #df5000">\'foo\'</span>&nbsp;}</div><div>&nbsp;</div><div><div style="display: inline-block; vertical-align: top"><div><span style="color: #999">&lt;</span><span style="color: #905">div</span><span style="color: #999">&gt;</span></div><div>&nbsp;&nbsp;<div style="display: inline-block; vertical-align: top"><div><span style="color: #999">&lt;</span><span style="color: #905">span</span><span style="color: #999">&gt;&lt;/</span><span style="color: #905">span</span><span style="color: #999">&gt;</span></div><div>&nbsp;</div></div>&nbsp;<div style="display: inline-block; vertical-align: top"><div><span style="color: red; font-weight: bold">//</span></div><div><span style="color: red; font-weight: bold">//</span></div><div><span style="color: red; font-weight: bold">//</span></div></div>&nbsp;<div style="display: inline-block; vertical-align: top"><div><span style="color: red; font-weight: bold">expected</span>&nbsp;<span style="color: #df5000">\'\'</span>&nbsp;<span style="color: red; font-weight: bold">to&nbsp;equal</span>&nbsp;<span style="color: #df5000">\'foo\'</span></div><div>&nbsp;</div><div><span style="color: green">foo</span></div></div></div><div><span style="color: #999">&lt;/</span><span style="color: #905">div</span><span style="color: #999">&gt;</span></div></div></div></div>'
+          );
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
This PR alters `unexpected-dom` to export the supporting styles corresponding to its exported assertions and types.

The rationale behind the implementation is to work within the following constraints:
- magicpen-prism is a magicpen plugin as well as an Unexpected plugin and should continue to function that way
  - -> it is the unexpected-dom that provides these facilities to its parent, therefore exporting all pre-requisites for its operation should remain its responsibility
- Unexpected currently manages children, and is the only component aware of "child" instances
  - -> for this reason, exportTheme() should remain a concept for Unexpected only

This PR depends on:
- https://github.com/unexpectedjs/unexpected/pull/681
- https://github.com/unexpectedjs/magicpen-prism/pull/5