### PR TITLE
Add ':focus' indicator in element start tag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -169,9 +169,13 @@ function getAttributes(element) {
 }
 
 function getStates(element) {
-  const result = {
-    focused: element.ownerDocument.activeElement === element,
-  };
+  const result = {};
+
+  try {
+    result.focused = element.ownerDocument.activeElement === element;
+  } catch (err) {
+    // The document might not be in a window, and thus not able to have an activeElement
+  }
 
   return result;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,14 @@ function getAttributes(element) {
   return result;
 }
 
+function getStates(element) {
+  const result = {
+    focused: element.ownerDocument.activeElement === element,
+  };
+
+  return result;
+}
+
 function entitify(value) {
   return String(value)
     .replace(/&/g, '&amp;')
@@ -222,10 +230,15 @@ function stringifyStartTag(element) {
     : element.nodeName;
   let str = `<${elementName}`;
   const attrs = getAttributes(element);
+  const states = getStates(element);
 
   Object.keys(attrs).forEach((key) => {
     str += ` ${stringifyAttribute(key, attrs[key])}`;
   });
+
+  if (elementName !== 'body' && states.focused) {
+    str += ' :focus';
+  }
 
   str += '>';
   return str;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -117,20 +117,29 @@ describe('unexpected-dom', () => {
   });
 
   describe('focus handling', () => {
+    var button;
+
+    beforeEach(() => {
+      button = root.document.createElement('button');
+      root.document.body.appendChild(button);
+    });
+
+    afterEach(() => {
+      button.parentNode.removeChild(button);
+    });
+
     it('should show a :focus indicator on a focused element', () => {
-      const subject = parseHtml('<button>I am focused</button>');
+      button.focus();
 
-      subject.focus();
-
-      expect(subject, 'to inspect as', '<button :focus>I am focused</button>');
+      expect(button, 'to inspect as', '<button :focus></button>');
     });
 
     it('should not show a :focus indicator on a focused <body>', () => {
-      const dpcument = parseHtmlDocument('');
+      const body = button.parentNode;
 
-      dpcument.body.focus();
+      body.focus();
 
-      expect(dpcument.body, 'to inspect as', '<body></body>');
+      expect(expect.inspect(body).toString(), 'to begin with', '<body>');
     });
   });
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -116,6 +116,24 @@ describe('unexpected-dom', () => {
     expect('<input value="">', 'to inspect as itself');
   });
 
+  describe('focus handling', () => {
+    it('should show a :focus indicator on a focused element', () => {
+      const subject = parseHtml('<button>I am focused</button>');
+
+      subject.focus();
+
+      expect(subject, 'to inspect as', '<button :focus>I am focused</button>');
+    });
+
+    it('should not show a :focus indicator on a focused <body>', () => {
+      const dpcument = parseHtmlDocument('');
+
+      dpcument.body.focus();
+
+      expect(dpcument.body, 'to inspect as', '<body></body>');
+    });
+  });
+
   describe('diffing', () => {
     expect.addAssertion(
       '<string|DOMNode|DOMDocument> diffed with <string|DOMNode|DOMDocument> <assertion>',


### PR DESCRIPTION
This adds a `:focus` indicator inside an elements start tag in the inspection output if the element is currently focused.

The `<body>` tag is explicitly exempt from this addition, since it is the initial focus element and would likely add surprising output to tests that do not deal with moving focus around.

Example output:

```html
<div role="tablist">
    <button id="tabs-1-0" aria-selected="true" role="tab" tabindex="0">...</button>
    <button id="tabs-1-1" aria-selected="false" role="tab" tabindex="-1">...</button>
    <button id="tabs-1-2" aria-selected="false" role="tab" tabindex="-1" :focus>...</button>
</div>
```

See focus testing thread starting at https://gitter.im/unexpectedjs/unexpected?at=5eba63cbfaa128031cc7f9e2