### PR TITLE
Add 'DOMElement to contain focused element' assertion

### DIFF
--- a/bootstrap-unexpected-markdown.js
+++ b/bootstrap-unexpected-markdown.js
@@ -1,4 +1,4 @@
-/* global unexpected:true, expect:true, jsdom:true, createElement:true */
+/* global unexpected:true, expect:true, jsdom:true, createElement:true, createDocument:true */
 /* eslint no-unused-vars: "off" */
 
 if (typeof expect === 'undefined') {
@@ -8,18 +8,29 @@ if (typeof expect === 'undefined') {
 unexpected = expect;
 unexpected.output.preferredWidth = 80;
 
-createElement = function createElement(html) {
-  var root = document.createElement('div');
-
-  root.innerHTML = html
+function sanitizeHtml(html) {
+  return html
     .replace(/^\s+|\s+$/gm, '')
     .replace(/\s*\n\s*</gm, '<')
     .replace(/>\s*\n\s*/gm, '>')
     .trim();
+}
+
+createElement = function createElement(html) {
+  var root = document.createElement('div');
+
+  root.innerHTML = sanitizeHtml(html);
 
   return root.firstChild;
 };
 
 /* eslint-disable no-global-assign */
 window = new jsdom.JSDOM().window;
+document = window.document;
+
+createDocument = function createDocument(html) {
+  return new jsdom.JSDOM(`<body>${sanitizeHtml(html)}</body>`).window.document;
+};
+
+/* eslint-disable no-global-assign */
 document = window.document;

--- a/documentation/assertions/DOMElement/to-contain-focused-element-matching.md
+++ b/documentation/assertions/DOMElement/to-contain-focused-element-matching.md
@@ -1,7 +1,7 @@
 Assert that a child element is the currently focused element on the page.
 
 ```js
-var element = createElement(`
+var document = createDocument(`
   <form>
   <label>
     <span>Name</span>
@@ -11,24 +11,21 @@ var element = createElement(`
   </form>
 `);
 
-element.querySelector('button').focus();
+var button = document.querySelector('button');
+button.focus();
 
-expect(element, 'to contain focused element matching', 'button');
+expect(document, 'to contain focused element matching', 'button');
 ```
 
 In case of a failing expectation you get the following output:
 
 ```js
-element.querySelector('button').blur();
-expect(element, 'to contain focused element matching', 'button');
+button.blur();
+expect(document, 'to contain focused element matching', 'button');
 ```
 
 ```output
-expected
-<form>
-  <label><span>...</span><input type="text"></label>
-  <button>Submit</button>
-</form>
+expected <html><head></head><body>...</body></html>
 to contain focused element matching 'button'
   expected <button>Submit</button> to have focus
 ```

--- a/documentation/assertions/DOMElement/to-contain-focused-element-matching.md
+++ b/documentation/assertions/DOMElement/to-contain-focused-element-matching.md
@@ -1,0 +1,34 @@
+Assert that a child element is the currently focused element on the page.
+
+```js
+var element = createElement(`
+  <form>
+  <label>
+    <span>Name</span>
+    <input type="text">
+  </label>
+  <button>Submit</button>
+  </form>
+`);
+
+element.querySelector('button').focus();
+
+expect(element, 'to contain focused element matching', 'button');
+```
+
+In case of a failing expectation you get the following output:
+
+```js
+element.querySelector('button').blur();
+expect(element, 'to contain focused element matching', 'button');
+```
+
+```output
+expected
+<form>
+  <label><span>...</span><input type="text"></label>
+  <button>Submit</button>
+</form>
+to contain focused element matching 'button'
+  expected <button>Submit</button> to have focus
+```

--- a/documentation/assertions/DOMElement/to-have-focus.md
+++ b/documentation/assertions/DOMElement/to-have-focus.md
@@ -1,29 +1,31 @@
 Assert that an element is the currently focused element on the page.
 
 ```js
-var element = createElement(`
+var document = createDocument(`
   <button>
     Focused
   </button>
 `);
 
-element.focus();
+var button = document.querySelector('button');
+button.focus();
 
-expect(element, 'to have focus');
+expect(button, 'to have focus');
 ```
 
 In case of a failing expectation you get the following output:
 
 ```js
-var element = createElement(`
+var document = createDocument(`
   <button>
     Not Focused
   </button>
 `);
 
-element.blur();
+var button = document.querySelector('button');
+button.blur();
 
-expect(element, 'to have focus');
+expect(button, 'to have focus');
 ```
 
 ```output
@@ -35,7 +37,7 @@ expected <button>Not Focused</button> to have focus
 You can combine this assertion with other assertions:
 
 ```js
-var element = createElement(`
+var document = createDocument(`
   <form>
   <label>
     <span>Name</span>
@@ -45,13 +47,15 @@ var element = createElement(`
   </form>
 `);
 
-element.querySelector('button').focus();
+var button = document.querySelector('button');
+button.focus();
 
 // Using a forwarding assertion
-expect(element, 'queried for first', 'button', 'to have focus');
+expect(document, 'queried for first', 'button', 'to have focus');
 
 // Using a nested assertion call
-expect(element, 'to satisfy', {
+var form = document.querySelector('form');
+expect(form, 'to satisfy', {
   children: [
     {
       name: 'label',

--- a/documentation/assertions/DOMElement/to-have-focus.md
+++ b/documentation/assertions/DOMElement/to-have-focus.md
@@ -1,0 +1,62 @@
+Assert that an element is the currently focused element on the page.
+
+```js
+var element = createElement(`
+  <button>
+    Focused
+  </button>
+`);
+
+element.focus();
+
+expect(element, 'to have focus');
+```
+
+In case of a failing expectation you get the following output:
+
+```js
+var element = createElement(`
+  <button>
+    Not Focused
+  </button>
+`);
+
+element.blur();
+
+expect(element, 'to have focus');
+```
+
+```output
+expected <button>Not Focused</button> to have focus
+```
+
+## Combining with other assertions
+
+You can combine this assertion with other assertions:
+
+```js
+var element = createElement(`
+  <form>
+  <label>
+    <span>Name</span>
+    <input type="text">
+  </label>
+  <button>Focused</button>
+  </form>
+`);
+
+element.querySelector('button').focus();
+
+// Using a forwarding assertion
+expect(element, 'queried for first', 'button', 'to have focus');
+
+// Using a nested assertion call
+expect(element, 'to satisfy', {
+  children: [
+    {
+      name: 'label',
+    },
+    expect.it('to have focus'),
+  ],
+});
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1861,5 +1861,12 @@ module.exports = {
         }
       }
     );
+
+    expect.exportAssertion(
+      '<DOMElement> [not] to have focus',
+      (expect, subject) => {
+        expect(subject.ownerDocument.activeElement, '[not] to be', subject);
+      }
+    );
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1865,7 +1865,11 @@ module.exports = {
     expect.exportAssertion(
       '<DOMElement> [not] to have focus',
       (expect, subject) => {
-        expect(subject.ownerDocument.activeElement, '[not] to be', subject);
+        let hasFocus = false;
+        try {
+          hasFocus = subject === subject.ownerDocument.activeElement;
+        } catch (err) {}
+        expect(hasFocus, '[not] to be true');
       }
     );
 

--- a/src/index.js
+++ b/src/index.js
@@ -1868,5 +1868,14 @@ module.exports = {
         expect(subject.ownerDocument.activeElement, '[not] to be', subject);
       }
     );
+
+    expect.exportAssertion(
+      '<DOMDocument|DOMElement> to contain focused element matching <string>',
+      (expect, subject, selector) => {
+        expect(subject, 'to contain elements matching', selector);
+        expect.errorMode = 'nested';
+        expect(subject.querySelector(selector), 'to have focus');
+      }
+    );
   },
 };

--- a/test/assertions/to-contain-focused-element-matching.js
+++ b/test/assertions/to-contain-focused-element-matching.js
@@ -1,0 +1,44 @@
+/* global expect, jsdom */
+
+describe('"to contain focused element matching" assertion', () => {
+  let body;
+
+  beforeEach(function () {
+    const root =
+      typeof jsdom !== 'undefined' ? new jsdom.JSDOM().window : window;
+    body = root.document.body;
+  });
+
+  it('should verify that a contained element is focused', () => {
+    body.innerHTML = '<button>Press me</button>';
+
+    body.firstChild.focus();
+
+    expect(body, 'to contain focused element matching', 'button');
+  });
+
+  it('should fail when selected element is not focused', () => {
+    body.innerHTML = '<button>Press me</button>';
+
+    expect(
+      () => {
+        expect(body, 'to contain focused element matching', 'button');
+      },
+      'to throw an error satisfying to equal snapshot',
+      expect.unindent`expected <body><button>Press me</button></body> to contain focused element matching 'button'
+  expected <button>Press me</button> to have focus`
+    );
+  });
+
+  it('should fail when selection matches nothing', () => {
+    body.innerHTML = '<button>Press me</button>';
+
+    expect(
+      () => {
+        expect(body, 'to contain focused element matching', 'div');
+      },
+      'to throw an error satisfying to equal snapshot',
+      expect.unindent`expected <body><button>Press me</button></body> to contain focused element matching 'div'`
+    );
+  });
+});

--- a/test/assertions/to-have-focus.js
+++ b/test/assertions/to-have-focus.js
@@ -1,0 +1,51 @@
+/* global expect, jsdom */
+
+describe('"to have focus" assertion', () => {
+  let body;
+
+  beforeEach(function () {
+    const root =
+      typeof jsdom !== 'undefined' ? new jsdom.JSDOM().window : window;
+    body = root.document.body;
+  });
+
+  it('should verify that an element is focused', () => {
+    body.innerHTML = '<button>Press me</button>';
+
+    body.firstChild.focus();
+
+    expect(body.firstChild, 'to have focus');
+  });
+
+  it('should fail when an element is not focused', () => {
+    body.innerHTML = '<button>Press me</button>';
+
+    expect(
+      () => {
+        expect(body.firstChild, 'to have focus');
+      },
+      'to throw an error satisfying to equal snapshot',
+      expect.unindent`expected <button>Press me</button> to have focus`
+    );
+  });
+
+  it('should verify that an element is not focused', () => {
+    body.innerHTML = '<button>Press me</button>';
+
+    expect(body.firstChild, 'not to have focus');
+  });
+
+  it('should fail when an element is focused', () => {
+    body.innerHTML = '<button>Press me</button>';
+
+    body.firstChild.focus();
+
+    expect(
+      () => {
+        expect(body.firstChild, 'not to have focus');
+      },
+      'to throw an error satisfying to equal snapshot',
+      expect.unindent`expected <button>Press me</button> not to have focus`
+    );
+  });
+});

--- a/test/assertions/to-have-focus.js
+++ b/test/assertions/to-have-focus.js
@@ -45,7 +45,7 @@ describe('"to have focus" assertion', () => {
         expect(body.firstChild, 'not to have focus');
       },
       'to throw an error satisfying to equal snapshot',
-      expect.unindent`expected <button>Press me</button> not to have focus`
+      expect.unindent`expected <button :focus>Press me</button> not to have focus`
     );
   });
 });


### PR DESCRIPTION
This adds a new convenience assertion to help with testing focus management.

```js
const component = mount(<Tabs tabs={tabs} defaultTab={0} />);

simulate(component, {
	type: "keyDown",
	target: '[role="tablist"]',
	data: {
		key: "End"
	}
});

expect(component, "to contain focused element matching", '[role="tab"]:nth-child(2)');
```

**Output with focus not even inside `component`**:

![image](https://user-images.githubusercontent.com/331790/81786536-1a2e4500-9500-11ea-9368-8ee722e056e6.png)

**Output with the wrong element focused**:

![image](https://user-images.githubusercontent.com/331790/81786584-2d411500-9500-11ea-9a3d-235679ef77d7.png)
