### PR TITLE
Fix to exhaustively satisfy for node lists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1005,7 +1005,7 @@ module.exports = {
               return bubbleError(() =>
                 expect(
                   isHtml ? subject.nodeName.toLowerCase() : subject.nodeName,
-                  'to satisfy',
+                  'to [exhaustively] satisfy',
                   value.name
                 )
               );
@@ -1030,13 +1030,17 @@ module.exports = {
               return bubbleError(() =>
                 expect(
                   makeAttachedDOMNodeList(subject.childNodes, contentType),
-                  'to satisfy',
+                  'to [exhaustively] satisfy',
                   value.children
                 )
               );
             } else if (typeof value.textContent !== 'undefined') {
               return bubbleError(() =>
-                expect(subject.textContent, 'to satisfy', value.textContent)
+                expect(
+                  subject.textContent,
+                  'to [exhaustively] satisfy',
+                  value.textContent
+                )
               );
             }
           }),
@@ -1097,7 +1101,11 @@ module.exports = {
                     );
                   }
 
-                  expect(attributeValue, 'to satisfy', expectedAttributeValue);
+                  expect(
+                    attributeValue,
+                    'to [exhaustively] satisfy',
+                    expectedAttributeValue
+                  );
                 });
               } else if (expectedAttributeValue === true) {
                 return bubbleError(() =>
@@ -1155,7 +1163,11 @@ module.exports = {
                   );
                 } else {
                   return bubbleError(() =>
-                    expect(attrs.style, 'to satisfy', expectedStyleObj)
+                    expect(
+                      attrs.style,
+                      'to [exhaustively] satisfy',
+                      expectedStyleObj
+                    )
                   );
                 }
               } else if (

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -264,6 +264,55 @@ describe('"to satisfy" assertion', () => {
     });
 
     describe('with the exhaustively flag', () => {
+      it('should succeed', () => {
+        expect(
+          '<div class="bar">foo</div>',
+          'when parsed as HTML fragment to exhaustively satisfy',
+          '<div class="bar">foo</div>'
+        );
+      });
+
+      it('should fail with a diff when comparing node lists', () => {
+        expect(
+          () => {
+            expect(
+              '<div class="guide-markup"><p class="wysiwyg-color-red130 guide-markup">Something</p></div><div class="guide-markup"><div class="guide-markup"><img class="some-existing-class guide-markup" src="image.png"></div></div>',
+              'when parsed as HTML to exhaustively satisfy',
+              '<div class="guide-markup"><p class="guide-markup wysiwyg-color-red130">Something</p></div><div class="guide-markup"><div class="guide-markup"><img src="image.png" class="guide-markup" /></div></div>'
+            );
+          },
+          'to throw an error satisfying to equal snapshot',
+          expect.unindent`
+            expected '<div class="guide-markup"><p class="wysiwyg-color-red130 guide-markup">Something</p></div><div class="guide-markup"><div class="guide-markup"><img class="some-existing-class guide-markup" src="image.png"></div></div>'
+            when parsed as HTML to exhaustively satisfy '<div class="guide-markup"><p class="guide-markup wysiwyg-color-red130">Something</p></div><div class="guide-markup"><div class="guide-markup"><img src="image.png" class="guide-markup" /></div></div>'
+              expected <html><head></head><body>...</body></html>
+              to exhaustively satisfy '<div class="guide-markup"><p class="guide-markup wysiwyg-color-red130">Something</p></div><div class="guide-markup"><div class="guide-markup"><img src="image.png" class="guide-markup" /></div></div>'
+
+              <html>
+                <head></head>
+                <body>
+                  <div class="guide-markup">
+                    <p class="wysiwyg-color-red130 guide-markup">...</p>
+                  </div>
+                  <div class="guide-markup">
+                    <div class="guide-markup">
+                      <img
+                        class="some-existing-class guide-markup" // expected [ 'guide-markup', 'some-existing-class' ] to equal [ 'guide-markup' ]
+                                                                 //
+                                                                 // [
+                                                                 //   'guide-markup',
+                                                                 //   'some-existing-class' // should be removed
+                                                                 // ]
+                        src="image.png"
+                      >
+                    </div>
+                  </div>
+                </body>
+              </html>
+          `
+        );
+      });
+
       it('should fail with a diff', () => {
         expect(
           () => {


### PR DESCRIPTION
We forgot to pass on the `exhaustively` flag.