### PR TITLE
Relax style validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,10 +86,7 @@ function isEnumeratedAttribute(attrName) {
 function validateStyles(expect, str) {
   const invalidStyles = str
     .split(';')
-    .filter(
-      (part) =>
-        !/^\s*(\w|-)+\s*:\s*(#(?:[0-9a-fA-F]{3}){1,2}|[^#]+)\s*$|^$/.test(part)
-    );
+    .filter((part) => !/^\s*(\w|-)+\s*:\s*|^\s*$/.test(part));
 
   if (invalidStyles.length > 0) {
     expect.errorMode = 'nested';

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -804,27 +804,13 @@ describe('"to satisfy" assertion', () => {
       );
     });
 
-    it.skipIf(isIe, 'should fail when the RHS has invalid styles', () =>
+    it('should not fail for a shorthand style attribute on the RHS', () => {
       expect(
-        () =>
-          expect(
-            parseHtml('<div style="border-left-color: #FFF">hey</div>'),
-            'to satisfy',
-            parseHtml('<div style="border-left-color: #FFFF;">hey</div>')
-          ),
-        'to throw an error satisfying to equal snapshot',
-        expect.unindent`
-          expected <div style="border-left-color: #FFF">hey</div>
-          to satisfy <div style="border-left-color: #FFFF">hey</div>
-
-          <div
-            style="border-left-color: #FFF" // expected <div style="border-left-color: #FFF">hey</div>
-                                            // to satisfy { name: 'div', attributes: { style: 'border-left-color: #FFFF;' }, children: [ hey ] }
-                                            //   Expectation contains invalid styles: 'border-left-color: #FFFF'
-          >hey</div>
-        `
-      )
-    );
+        parseHtml('<div style="border: 2px dashed #960FD4;">hey</div>'),
+        'to satisfy',
+        parseHtml('<div style="border: 2px dashed #960FD4;">hey</div>')
+      );
+    });
 
     it.skipIf(isIe, 'should fail when the RHS has invalid styles', () =>
       expect(


### PR DESCRIPTION
After https://github.com/unexpectedjs/unexpected-dom/pull/247 the style regex became way too restrictive and doesn't allow shorthand values like:

border: thin solid red;

So I think we should just completely relax the style regex as it isn't really giving us any value.